### PR TITLE
Oakland Game Devs -> East Bay Game Devs

### DIFF
--- a/02.events/default.md
+++ b/02.events/default.md
@@ -12,8 +12,8 @@ Events have gone virtual! South Bay Game Dev meets the last monday of every mont
   * Monthly meetup group that meets in Campbell on the last monday of the month, chill chatting & demoing type environment.
 * [SF Game Development](https://www.meetup.com/Monthly-SF-Game-Development-Community)
   * This group hosts high-quality meetups focused on topics such as game marketing, development, and design.
-* [Oakland Game Devs & Creatives](https://www.meetup.com/OaklandGameDevs/)
-  * Oakland Game Devs & Creatives is a friendly Meetup in the East Bay for industry professionals, independent game developers, hobbyists, artists, musicians, designers, and those interested in breaking into video game development.
+* [East Bay Game Devs & Creatives](https://www.meetup.com/EastBayGameDevs/)
+  * East Bay Game Devs & Creatives is a friendly Meetup in Oakland and surrounding areas for industry professionals, independent game developers, hobbyists, artists, musicians, designers, and those interested in breaking into video game development.
 * [Virtual World Arcade](https://www.meetup.com/Virtual-World-Arcade/)
   * Ever wanted to live a video game experience? Now you can! Enter the Virtual World and play VR games with your friends at Virtual World Arcade!
 * [Sacramento Developer Collective](https://www.meetup.com/gamedeveloper/)


### PR DESCRIPTION
Changed the East Bay group name. Title, URL, and description have been updated.